### PR TITLE
Fixes LoginHttpAuth to respect [General] login_logout_url setting

### DIFF
--- a/Controller.php
+++ b/Controller.php
@@ -10,6 +10,8 @@ namespace Piwik\Plugins\LoginHttpAuth;
 
 use Piwik\Session;
 use Piwik\View;
+use Piwik\Config;
+use Piwik\Url;
 
 class Controller extends \Piwik\Plugins\Login\Controller
 {
@@ -24,7 +26,14 @@ class Controller extends \Piwik\Plugins\Login\Controller
 
     public function logout()
     {
-        $view = new View('@LoginHttpAuth/logout');
-        return $view->render();
+        self::clearSession();
+
+        $logoutUrl = @Config::getInstance()->General['login_logout_url'];
+        if(empty($logoutUrl)) {
+            $view = new View('@LoginHttpAuth/logout');
+            return $view->render();
+        } else {
+            Url::redirectToUrl($logoutUrl);
+        }
     }
 }


### PR DESCRIPTION
I need to send the user over to a SSO logout page after their Piwik session is destroyed, but LoginHttpAuth does not currently respect the login_logout_url setting.  This patch fixes it for me and should not break existing setups: if login_logout_url is not set, it falls back to the original behavior of loading the LoginHttpAuth/logout view.