### PR TITLE
Opt-out iframe broken with Piwik 2.15

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -27,6 +27,7 @@ class Auth extends \Piwik\Plugins\Login\Auth
      */
     public function __construct(Model $userModel = null)
     {
+        parent::__construct();
         if ($userModel === null) {
             $userModel = new Model();
         }


### PR DESCRIPTION
Parent class also needs to create a userModel because a private
variable is used.
Needed since Piwik 2.15, otherwise the opt-out iframe doesn’t work.

Parent class was changed here:
https://github.com/piwik/piwik/commit/0c96ca8ce664605dcfaf473e98c84399b11f3b6d#diff-cd19cab3b7d93f142e18f2cb45c928a2