### PR TITLE
Use composition instead of inheritance in Auth class

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -13,12 +13,17 @@ use Piwik\DB;
 use Piwik\Plugins\Login;
 use Piwik\Plugins\UsersManager\Model;
 
-class Auth extends \Piwik\Plugins\Login\Auth
+class Auth implements \Piwik\Auth
 {
     /**
      * @var Model
      */
     private $userModel;
+
+    /**
+     * @var Auth
+     */
+    private $fallbackAuth;
 
     /**
      * Constructor.
@@ -32,6 +37,7 @@ class Auth extends \Piwik\Plugins\Login\Auth
         }
 
         $this->userModel = $userModel;
+        $this->fallbackAuth = new \Piwik\Plugins\Login\Auth();
     }
 
     /**
@@ -63,7 +69,7 @@ class Auth extends \Piwik\Plugins\Login\Auth
             return new AuthResult($code, $httpLogin, $user['token_auth']);
 
         }
-        return parent::authenticate();
+        return $this->fallbackAuth->authenticate();
     }
 
     protected function getHttpAuthLogin()
@@ -79,6 +85,36 @@ class Auth extends \Piwik\Plugins\Login\Auth
             $httpLogin = $_ENV['REDIRECT_REMOTE_USER'];
         }
         return $httpLogin;
+    }
+
+    public function setTokenAuth($token_auth)
+    {
+        $this->fallbackAuth->setTokenAuth($token_auth);
+    }
+
+    public function getLogin()
+    {
+        $this->fallbackAuth->getLogin();
+    }
+
+    public function getTokenAuthSecret()
+    {
+        return $this->fallbackAuth->getTokenAuthSecret();
+    }
+
+    public function setLogin($login)
+    {
+        $this->fallbackAuth->setLogin($login);
+    }
+
+    public function setPassword($password)
+    {
+        $this->fallbackAuth->setPassword($password);
+    }
+
+    public function setPasswordHash($passwordHash)
+    {
+        $this->fallbackAuth->setPasswordHash($passwordHash);
     }
 }
 

--- a/tests/Integration/AuthTest.php
+++ b/tests/Integration/AuthTest.php
@@ -71,4 +71,26 @@ class AuthTest extends IntegrationTestCase
 
         $this->assertEquals(AuthResult::SUCCESS_SUPERUSER_AUTH_CODE, $result->getCode());
     }
+
+    public function test_Auth_DelegatesToLoginAuth_WhenHttpServerDidntAuthenticate_AuthenticatingByPassword()
+    {
+        unset($_SERVER['PHP_AUTH_USER']);
+
+        $this->auth->setLogin(self::TEST_USER);
+        $this->auth->setPassword('anotherparttimer');
+        $result = $this->auth->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+    }
+
+    public function test_Auth_DelegatesToLoginAuth_WhenHttpServerDidntAuthenticate_AuthenticatingByTokenAuth()
+    {
+        unset($_SERVER['PHP_AUTH_USER']);
+
+        $this->auth->setLogin(self::TEST_USER);
+        $this->auth->setTokenAuth(UsersManagerAPI::getInstance()->getTokenAuth(self::TEST_USER, md5('anotherparttimer')));
+        $result = $this->auth->authenticate();
+
+        $this->assertEquals(AuthResult::SUCCESS, $result->getCode());
+    }
 }

--- a/tests/System/PiwikAuthTest.php
+++ b/tests/System/PiwikAuthTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * Piwik - free/libre analytics platform
+ *
+ * @link http://piwik.org
+ * @license http://www.gnu.org/licenses/gpl-3.0.html GPL v3 or later
+ */
+
+namespace Piwik\Plugins\LoginHttpAuth\tests\System;
+
+use Piwik\Access;
+use Piwik\API\Request;
+use Piwik\Common;
+use Piwik\Container\StaticContainer;
+use Piwik\Date;
+use Piwik\Db;
+use Piwik\FrontController;
+use Piwik\Tests\Framework\Fixture;
+use Piwik\Tests\Framework\TestCase\IntegrationTestCase;
+use Piwik\Version;
+
+/**
+ * @group LoginHttpAuth
+ * @group LoginHttpAuth_System
+ */
+class PiwikAuthTest extends IntegrationTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->skipTestIfPiwikLessThan2_15_1();
+
+        FrontController::getInstance()->init();
+        Fixture::createWebsite('2012-01-01 00:00:00');
+
+        // sanity checks
+        $this->assertTrue(empty($_SERVER['PHP_AUTH_USER']));
+        $this->assertInstanceOf('Piwik\Plugins\LoginHttpAuth\Auth', StaticContainer::get('Piwik\Auth'));
+    }
+
+    public function test_TrackerAuthentication_DoesNotFail_WhenLoginHttpAuthIsUsed()
+    {
+        $date = Date::factory('2015-01-01 00:00:00');
+
+        $tracker = Fixture::getTracker($idSite = 1, $date->addHour(1)->getDatetime());
+        $tracker->setTokenAuth(Fixture::getTokenAuth());
+
+        $tracker->setUrl('http://shield.org/protocol/theta');
+        Fixture::checkResponse($tracker->doTrackPageView('I Am A Robot Tourist'));
+
+        // authentication is required to track dates in the past, so to verify we
+        // authenticated, we check the tracked visit times
+        $expectedDateTimes = array('2015-01-01 01:00:00');
+        $actualDateTimes = $this->getVisitDateTimes();
+
+        $this->assertEquals($expectedDateTimes, $actualDateTimes);
+    }
+
+    public function test_BulkTrackingAuthentication_DoesNotFail_WhenLoginHttpAuthIsUsed()
+    {
+        $superUserTokenAuth = Fixture::getTokenAuth();
+
+        $date = Date::factory('2015-01-01 00:00:00');
+
+        $tracker = Fixture::getTracker($idSite = 1, $date->getDatetime());
+        $tracker->setTokenAuth($superUserTokenAuth);
+        $tracker->enableBulkTracking();
+
+        $tracker->setForceVisitDateTime($date->getDatetime());
+        $tracker->setUrl('http://shield.org/level/10/dandr/pcoulson');
+        $tracker->doTrackPageView('Death & Recovery');
+
+        $tracker->setForceVisitDateTime($date->addHour(1)->getDatetime());
+        $tracker->setUrl('http://shield.org/logout');
+        $tracker->doTrackPageView('Going dark');
+
+        Fixture::checkBulkTrackingResponse($tracker->doBulkTrack());
+
+        // authentication is required to track dates in the past, so to verify we
+        // authenticated, we check the tracked visit times
+        $expectedDateTimes = array('2015-01-01 00:00:00', '2015-01-01 01:00:00');
+        $actualDateTimes = $this->getVisitDateTimes();
+
+        $this->assertEquals($expectedDateTimes, $actualDateTimes);
+    }
+
+    /**
+     * @dataProvider getApiRequestAuthTests
+     */
+    public function test_ApiRequestAuthentication_DoesNotFail_WhenLoginHttpAuthIsUsed($useHttpAuth)
+    {
+        Access::getInstance()->setSuperUserAccess(false);
+
+        $_GET = array(
+            'idSite' => 1,
+            'date' => '2012-01-01',
+            'period' => 'day',
+            'module' => 'API',
+            'method' => 'VisitsSummary.get',
+        );
+
+        if ($useHttpAuth) {
+            $_SERVER['PHP_AUTH_USER'] = Fixture::ADMIN_USER_LOGIN;
+        } else {
+            $_GET['token_auth'] = Fixture::getTokenAuth();
+        }
+
+        $frontController = FrontController::getInstance();
+        $frontController->init();
+        $output = $frontController->dispatch();
+
+        $this->assertNotContains('error', $output);
+    }
+
+    public function getApiRequestAuthTests()
+    {
+        return array(
+            array(true),
+            array(false),
+        );
+    }
+
+    private function getVisitDateTimes()
+    {
+        $rows = Db::fetchAll("SELECT visit_last_action_time FROM " . Common::prefixTable('log_visit')
+            . " ORDER BY visit_last_action_time ASC");
+
+        $dates = array();
+        foreach ($rows as $row) {
+            $dates[] = $row['visit_last_action_time'];
+        }
+        return $dates;
+    }
+
+    protected static function configureFixture($fixture)
+    {
+        parent::configureFixture($fixture);
+        $fixture->createSuperUser = true;
+    }
+
+    private function skipTestIfPiwikLessThan2_15_1()
+    {
+        if (version_compare(Version::VERSION, '2.15.0', '<=')) {
+            $this->markTestSkipped("These tests will not pass unless ");
+        }
+    }
+}


### PR DESCRIPTION
The Auth class was not calling the base __construct method causing authentication problems when LoginHttpAuth is used.

This PR fixes this bug + adds tests for the problem + a new system test. The system test will not pass until https://github.com/piwik/piwik/pull/9119 is merged.

Fixes https://github.com/piwik/piwik/issues/9087