### PR TITLE
Plugin compatibility with Piwik 2.16.0-b6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 
 language: php
 
+group: legacy
+
 php:
   - 5.6
   - 5.3.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
   global:
     - PLUGIN_NAME=LoginHttpAuth
     - PIWIK_ROOT_DIR=$TRAVIS_BUILD_DIR/piwik
-    - PIWIK_LATEST_STABLE_TEST_TARGET=2.15.0-rc4
+    - PIWIK_LATEST_STABLE_TEST_TARGET=2.16.0-b6
     - secure: "raplCvqQ9NUqBnarkxWMuFRvvNgA1Ucej6kLiBgL70h8SsbBr+hXo58Vmf2l7ph5yCNH1crimkB7Wj0oYXOEusCaQBoOrgAzkp0FJJXI8opBV+hubNVGKYaG9Hhn+H/SLuP6lKEShY0dcw5iR3jYPQEGqj0SF5YwbE9s0GbfqQo="
     - secure: "PJuO6L2OhAiBV6lxeZfZ3ax1E7IVK1UpzMacdDnq8r0nFoTYKnqwH0hpjmpiSvnpdjk6jenJVg5pIg828azoWK4ZQXDzA1rGikZUEzQEYTGSo2KCrEw/RZmBc8mXbnH4du/wCIH/J/P9ImqW4gk7etB83BES6v49c3peXB1uTek="
   matrix:


### PR DESCRIPTION
If you merge this PR manually and there is a version bump, you must remember to tag the new version.

This PR contains changes required to make LoginHttpAuth compatible with Piwik 2.16.0-b6.

It should be reviewed, then after all similar PRs are reviewed, they will be merged by a command.

* [ ] Reviewed (make sure to confirm build is green).

Check the above box to let the command know this PR has been reviewed.