### PR TITLE
allow http-header "X-Auth-Username" to be a valid source to authentic…

### DIFF
--- a/Auth.php
+++ b/Auth.php
@@ -83,6 +83,8 @@ class Auth implements \Piwik\Auth
             $httpLogin = $_ENV['AUTH_USER'];
         } elseif (isset($_ENV['REMOTE_USER'])) {
             $httpLogin = $_ENV['REMOTE_USER'];
+        } elseif (isset($_SERVER['HTTP_X_AUTH_USERNAME'])) {
+            $httpLogin = $_SERVER['HTTP_X_AUTH_USERNAME'];
         } elseif (isset($_ENV['REDIRECT_REMOTE_USER'])) {
             $httpLogin = $_ENV['REDIRECT_REMOTE_USER'];
         }

--- a/Controller.php
+++ b/Controller.php
@@ -16,9 +16,13 @@ class Controller extends \Piwik\Plugins\Login\Controller
     {
         // Effectively log out of Http auth
         $settings = new SystemSettings('LoginHttpAuth');
-        header('WWW-Authenticate: Basic realm="'. $settings->authName->getValue() .'"');
-        header('HTTP/1.0 401 Unauthorized');
-        self::clearSession();
+        if (isset($_SERVER['HTTP_X_AUTH_USERNAME'])) {
+            // there is no way to log our session out so we do nothing
+        } else {
+            header('WWW-Authenticate: Basic realm="'. $settings->authName->getValue() .'"');
+            header('HTTP/1.0 401 Unauthorized');
+            self::clearSession();
+        } endif
     }
 
     public function logout()


### PR DESCRIPTION
…ate the user

https://github.com/gambol99/keycloak-proxy adds the Header "X-Auth-Username" after a succesful authentication with a oauth-provider. Allow this http-header as a trusted source for the username

When using the keycloak-proxy one can achieve Single-Sign-On to Piwik using any oauth2-provider. Just be sure to allow access to piwik (index.php) only after being authenticated by the keycloak-proxy. 

I gonna create a gist with the setup for this using nginx with https and the keycloak-proxy in front of piwik. 